### PR TITLE
Fix for the final training of the train method for backwards models

### DIFF
--- a/mtrf/model.py
+++ b/mtrf/model.py
@@ -222,7 +222,7 @@ class TRF:
                     verbose=verbose,
                 )
             best_regularization = list(regularization)[np.argmin(mse)]
-            self._train(stimulus, response, fs, tmin, tmax, best_regularization)
+            self._train(xs, ys, fs, tmin, tmax, best_regularization)
             return r, mse
 
     def _train(self, xs, ys, fs, tmin, tmax, regularization):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -40,6 +40,17 @@ def test_predict():
     prediction, r, mse = trf.predict(stimulus, response, average=False)
     assert r.shape[-1] == mse.shape[-1] == trf.weights.shape[-1]
 
+    # Backwards prediction
+    trf = TRF(-1)
+    trf.train(stimulus, response, fs, tmin, tmax, regularization)
+    for average in [True, list(range(randint(stimulus[0].shape[-1])))]:
+        prediction, r, mse = trf.predict(stimulus, response, average=average)
+        assert len(prediction) == len(stimulus)
+        assert all([p[0].shape == s[0].shape for p, s in zip(prediction, stimulus)])
+        assert np.isscalar(r) and np.isscalar(mse)
+    prediction, r, mse = trf.predict(stimulus, response, average=False)
+    assert r.shape[-1] == mse.shape[-1] == trf.weights.shape[-1]
+
 
 def test_test():
     tmin = np.random.uniform(-0.1, 0.05)


### PR DESCRIPTION
First of all: Nice work on the package!

When training a backward model with multiple regularization values, the last `_train` call on line 255 uses `stimuli` and `responses` instead of `xs` and `ys` (as on line 185 in [mtrf/model.py](mtrf/model.py)), leading to wrong weights and biases. 

In my case, this was not obvious until `predict` was called and `numpy` raised a `ValueError` because the reshaping of the weights failed. I've adapted the unittest for `predict` to catch this issue, in case it would re-appear.

Kind regards,
Bernd