### PR TITLE
Paper fix suggestions

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -87,7 +87,7 @@
 }
 
 @article{gramfort2013,
-  title={MEG and EEG data analysis with MNE-Python},
+  title={MEG and EEG data analysis with MNE-{P}ython},
   author={Gramfort, Alexandre and Luessi, Martin and Larson, Eric and Engemann, Denis A and Strohmeier, Daniel and Brodbeck, Christian and Goj, Roman and Jas, Mainak and Brooks, Teon and Parkkonen, Lauri and Hämäläinen, Matti},
   journal={Frontiers in Neuroscience},
   pages={267},

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -9,7 +9,7 @@
 }
 
 @article{mischler2023,
-  title={naplib-python: Neural Acoustic Data Processing and Analysis Tools in Python},
+  title={{n}aplib-python: Neural Acoustic Data Processing and Analysis Tools in {P}ython},
   author={Mischler, Gavin and Raghavan, Vinay and Keshishian, Menoua and Mesgarani, Nima},
   journal={arXiv preprint arXiv:2304.01799},
   year={2023},
@@ -41,7 +41,7 @@
 
 @article{osullivan2015,
   title={Attentional selection in a cocktail party environment can be decoded from single-trial EEG},
-  author={O'sullivan, James A and Power, Alan J and Mesgarani, Nima and Rajaram, Siddharth and Foxe, John J and Shinn-Cunningham, Barbara G and Slaney, Malcolm and Shamma, Shihab A and Lalor, Edmund C},
+  author={O'Sullivan, James A and Power, Alan J and Mesgarani, Nima and Rajaram, Siddharth and Foxe, John J and Shinn-Cunningham, Barbara G and Slaney, Malcolm and Shamma, Shihab A and Lalor, Edmund C},
   journal={Cerebral cortex},
   volume={25},
   number={7},
@@ -64,7 +64,7 @@
 
 @article{diliberto2015,
   title={Low-frequency cortical entrainment to speech reflects phoneme-level processing},
-  author={Di Liberto, Giovanni M and O’sullivan, James A and Lalor, Edmund C},
+  author={Di Liberto, Giovanni M and O’Sullivan, James A and Lalor, Edmund C},
   journal={Current Biology},
   volume={25},
   number={19},
@@ -88,8 +88,8 @@
 
 @article{gramfort2013,
   title={MEG and EEG data analysis with MNE-Python},
-  author={Gramfort, Alexandre and Luessi, Martin and Larson, Eric and Engemann, Denis A and Strohmeier, Daniel and Brodbeck, Christian and Goj, Roman and Jas, Mainak and Brooks, Teon and Parkkonen, Lauri and others},
-  journal={Frontiers in neuroscience},
+  author={Gramfort, Alexandre and Luessi, Martin and Larson, Eric and Engemann, Denis A and Strohmeier, Daniel and Brodbeck, Christian and Goj, Roman and Jas, Mainak and Brooks, Teon and Parkkonen, Lauri and Hämäläinen, Matti},
+  journal={Frontiers in Neuroscience},
   pages={267},
   year={2013},
   doi={10.3389/fnins.2013.00267},

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -36,35 +36,35 @@ Recently, researchers have increasingly focused on investigating brain responses
 However, this approach demands statistical tools to account for the different sources of variance that naturally occur in speech. 
 Among the most popular tools to model neural responses to naturalistic speech are multivariate temporal response functions (mTRFs).
 
-One of the most commonly used packages for computing mTRFs with regularized regression is the mTRF-toolbox [@crosse2016]. 
+One of the most commonly used packages for computing mTRFs with regularized regression is the `mTRF`-toolbox [@crosse2016]. 
 However, this toolbox is implemented in the proprietary MATLAB language, restricting accessibility for parts of the scientific community. 
-To overcome this constraint, we present mTRFpy, a Python package which replicates and advances the functionality of the original mTRF-toolbox.
+To overcome this constraint, we present `mTRFpy`, a Python package which replicates and advances the functionality of the original `mTRF`-toolbox.
 
 # Background
 In a nutshell, the mTRF is a regularized linear regression between two continuous signals, computed across multiple time-delays or lags.
 This accounts for the fact that the relationship between stimulus and neural response is not instantaneous and that the signals are auto-correlated.
 
-mTRFs can be used as forward or encoding models to predict (multiple) univariate brain responses as the weighted sum of various acoustic and linguistic speech features while identifying their relative contributions [@diliberto2015, broderick2018].
+mTRFs can be used as forward or encoding models to predict (multiple) univariate brain responses as the weighted sum of various acoustic and linguistic speech features while identifying their relative contributions [@diliberto2015, @broderick2018].
 In this case the model's weights have a clear physiological interpretation because they denote the expected change in neural response following a unit change in a given predictor [@haufe2014]. 
 Thus, they can be understood as a generalization of the event potential, obtained from averaging responses to repetitions of prototypical stimuli for continuous data.
 
 mTRFs can also be used as backward or decoding models which reconstruct stimulus features from multivariate neural recordings, for example to identify the speaker an individual is attending to within a cocktail party scenario [@osullivan2015]. 
 Because a decoder pools information across all neural sensors, it can leverage interactions between individual observations and their underlying generators. 
-Thus their predictive power is usually higher compared to encoding models. 
+Thus, their predictive power is usually higher compared to encoding models. 
 However, because the neural signals are highly interrelated, the decoder will not only amplify relevant, but suppress irrelevant signals, making a physiological interpretation of the weights difficult [@haufe2014].
 
 # Statement of need
 The temporal response function is a powerful and versatile tool to study the neural processing of speech in its natural complexity.
-They also allow researchers to conduct experiments that are engaging (e.g., listening to a conversation) while monitoring the comprehension of speech independently of classical behavioral tests.
+It also allows researchers to conduct experiments that are engaging (e.g., listening to a conversation) while monitoring the comprehension of speech independently of classical behavioral tests.
 This makes mTRFs promising tools for clinical applications in infants or patients with schizophrenia, autism spectrum disorder or disorder of consciousness.
 We believe that mTRFs can be useful to a large clinical research community and hope that open and accessible software will facilitate their wider adoption.
 
-We implement the same methods as the original MATLAB toolbox and use a sample data set to demonstrate that mTRFpy produces the same results (within the limits of numerical accuracy).
+We implement the same methods as the original MATLAB toolbox and use a sample data set to demonstrate that `mTRFpy` produces the same results (within the limits of numerical accuracy).
 However, we use an object oriented design, where training, optimization and visualization are implemented as methods of a generic `TRF` class.
-What is more, we added functions for permutation testing and model evaluation which were not included in the original mTRF-toolbox.
-Finally, we also included a method to conveniently export trained models to MNE-Python which is the most common framework for analyzing MEG and EEG data in Python [@gramfort2013].
+What is more, we added functions for permutation testing and model evaluation which were not included in the original `mTRF`-toolbox.
+Finally, we also included a method to conveniently export trained models to `MNE-Python` which is the most common framework for analyzing MEG and EEG data in Python [@gramfort2013].
 
-There is some overlap with other Python packages focused on the neural processing of naturalistic speech such as eelbrain [@brodbeck2021] and naplib [@mischler2023]. 
+There is some overlap with other Python packages focused on the neural processing of naturalistic speech such as `eelbrain` [@brodbeck2021] and `naplib` [@mischler2023]. 
 However, while these packages provide a whole analysis framework, `mTRFpy` is more minimalist in its implementation. 
 This makes `mTRFpy` easy to learn, keeps dependencies to a minimum and makes the package easy to integrate into a broad variety of analysis pipelines.
 


### PR DESCRIPTION
These are fixes suggested as part of the review process at JOSS: https://github.com/openjournals/joss-reviews/issues/5657

Hi @OleBialas,
some minor fixes I am suggesting for the paper. 
Overview:
- I fixed some references in the `.bib` file. Not sure the capitalization changes to Mischler et al. and Gramfort et al. will work (they would in plain LaTeX but let's double check for Markdown!)
- You had put some of the toolbox names in backticks, I added that for the rest of the text
- fixed the reference Broderick et al.
- some other misc. things
