### PR TITLE
Fix references

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,5 +1,5 @@
 @article{brodbeck2021,
-  title={Eelbrain: A Python toolkit for time-continuous analysis with temporal response functions},
+  title={Eelbrain: A {P}ython toolkit for time-continuous analysis with temporal response functions},
   author={Brodbeck, Christian and Das, Proloy and Gillis, Marlies and Kulasingham, Joshua P and Bhattasali, Shohini and Gaston, Phoebe and Resnik, Philip and Simon, Jonathan Z},
   journal={BioRxiv},
   pages={2021--08},

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -44,7 +44,7 @@ To overcome this constraint, we present `mTRFpy`, a Python package which replica
 In a nutshell, the mTRF is a regularized linear regression between two continuous signals, computed across multiple time-delays or lags.
 This accounts for the fact that the relationship between stimulus and neural response is not instantaneous and that the signals are auto-correlated.
 
-mTRFs can be used as forward or encoding models to predict (multiple) univariate brain responses as the weighted sum of various acoustic and linguistic speech features while identifying their relative contributions [@diliberto2015, @broderick2018].
+mTRFs can be used as forward or encoding models to predict (multiple) univariate brain responses as the weighted sum of various acoustic and linguistic speech features while identifying their relative contributions [@diliberto2015; @broderick2018].
 In this case the model's weights have a clear physiological interpretation because they denote the expected change in neural response following a unit change in a given predictor [@haufe2014]. 
 Thus, they can be understood as a generalization of the event potential, obtained from averaging responses to repetitions of prototypical stimuli for continuous data.
 


### PR DESCRIPTION
Hi @OleBialas,

The citation I tried to fix [previously](https://github.com/powerfulbean/mTRFpy/pull/26) was still messed up, sorry. Plus, I had overlooked a capitalization in a reference.

This is related to the JOSS reviewing process over in https://github.com/openjournals/joss-reviews/issues/5657