### PR TITLE
modified:   mtrf/model.py

### DIFF
--- a/mtrf/model.py
+++ b/mtrf/model.py
@@ -479,7 +479,7 @@ class TRF:
         if plt is None:
             raise ModuleNotFoundError("Need matplotlib to plot TRF!")
         if self.direction == -1:
-            weights = self.weight.T
+            weights = self.weights.T
             print(
                 "WARNING: decoder weights are hard to interpret, consider using the `to_forward()` method"
             )


### PR DESCRIPTION
The plot() method inside the TRF class defined in mtrf/model.py has a variable with an error. self.weight is changed to self.weights.