### PR TITLE
Add array-API support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+*pixi*
 # C extensions
 *.so
 

--- a/mtrf/matrices.py
+++ b/mtrf/matrices.py
@@ -85,7 +85,6 @@ def _check_length(stimulus, response, crop=True) -> Tuple[ArrayList, ArrayList, 
     if crop is True:
         min_n = [min(len(r), len(s)) for r, s in zip(response, stimulus)]
         for i, (r, s, n) in enumerate(zip(response, stimulus, min_n)):
-            print(s[i].shape, r[i].shape)
             stimulus[i] = s[:n, :]
             response[i] = r[:n, :]
     return stimulus, response, len(stimulus)

--- a/mtrf/matrices.py
+++ b/mtrf/matrices.py
@@ -49,7 +49,7 @@ def _check_data(
     return data, xp
 
 
-def _check_length(stimulus, response, min_trials) -> int:
+def _check_length(stimulus, response) -> int:
     """
     Assert stimulus and response have the same number of trials with the same length.
 
@@ -59,8 +59,6 @@ def _check_length(stimulus, response, min_trials) -> int:
             List of stimulus trials.
         response: list of array-like
             List of response trials.
-        min_trals:int
-            Minimum required number of trials.
 
     Returns
     -------
@@ -80,8 +78,6 @@ def _check_length(stimulus, response, min_trials) -> int:
     assert all(
         [s.shape[0] == r.shape[0] for s, r in zip(stimulus, response)]
     ), "stimulus and response trials must have the same length!"
-    n_trials = len(stimulus)
-    assert n_trials < min_trials, "Too few trials!"
     return len(stimulus)
 
 

--- a/mtrf/matrices.py
+++ b/mtrf/matrices.py
@@ -85,8 +85,9 @@ def _check_length(stimulus, response, crop=True) -> Tuple[ArrayList, ArrayList, 
     if crop is True:
         min_n = [min(len(r), len(s)) for r, s in zip(response, stimulus)]
         for i, (r, s, n) in enumerate(zip(response, stimulus, min_n)):
-            stimulus[i] = s[i][:n, :]
-            response[i] = r[i][:n, :]
+            print(s[i].shape, r[i].shape)
+            stimulus[i] = s[:n, :]
+            response[i] = r[:n, :]
     return stimulus, response, len(stimulus)
 
 

--- a/mtrf/matrices.py
+++ b/mtrf/matrices.py
@@ -255,10 +255,10 @@ def lag_matrix(
             x_lag[:, col_slice] = x
 
     if zeropad is False:
-        x_lag = truncate(lag_matrix, lags[0], lags[-1])
+        x_lag = truncate(x_lag, lags[0], lags[-1])
 
     if bias is not False:
-        x_lag = xp.concatenate([xp.ones((x_lag.shape[0], 1)), lag_matrix], 1)
+        x_lag = xp.concatenate([xp.ones((x_lag.shape[0], 1)), x_lag], 1)
 
     return x_lag
 

--- a/mtrf/model.py
+++ b/mtrf/model.py
@@ -211,7 +211,7 @@ class TRF:
             raise ValueError("Average must be True or a list of indices!")
         stimulus, xps = _check_data(stimulus)
         response, xpr = _check_data(response)
-        n_trials = _check_length(stimulus, response)
+        stimulus, response, n_trials = _check_length(stimulus, response)
         if not xps == xpr:
             raise TypeError("stimulus and response trials must be of the same type!")
         else:
@@ -346,18 +346,22 @@ class TRF:
             raise ValueError("Need stimulus to predict with a forward model!")
         elif self.direction == -1 and response is None:
             raise ValueError("Need response to predict with a backward model!")
-        stimulus, xps = _check_data(stimulus)
-        response, xpr = _check_data(response)
-        n_trials = _check_length(stimulus, response)
-        if not xps == xpr:
-            raise TypeError("stimulus and response trials must be of the same type!")
-        else:
-            xp = xps
         if stimulus is None:
-            stimulus = [None for _ in range(n_trials)]
+            stimulus = [None for _ in range(len(response))]
+        else:
+            stimulus, xps = _check_data(stimulus)
+            xp = xps
         if response is None:
-            response = [None for _ in range(n_trials)]
-
+            response = [None for _ in range(len(stimulus))]
+        else:
+            response, xpr = _check_data(response)
+            xp = xpr
+        if stimulus[0] is not None and response[0] is not None:
+            stimulus, response, _ = _check_length(stimulus, response)
+            if not xps == xpr:
+                raise TypeError(
+                    "stimulus and response trials must be of the same type!"
+                )
         x, y, _, _ = _get_xy(
             stimulus,
             response,

--- a/mtrf/model.py
+++ b/mtrf/model.py
@@ -253,6 +253,7 @@ class TRF:
                     fs,
                     regularization[ir],
                     k,
+                    xp,
                     seed=seed,
                     average=average,
                     verbose=verbose,

--- a/mtrf/model.py
+++ b/mtrf/model.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
 from pathlib import Path
+from typing import Literal, Union, List, Tuple
+from types import ModuleType
 from itertools import product
 import pickle
 from collections.abc import Iterable
@@ -7,7 +10,6 @@ from mtrf.stats import (
     _crossval,
     _progressbar,
     _check_k,
-    neg_mse,
     pearsonr,
 )
 from mtrf.matrices import (
@@ -17,8 +19,12 @@ from mtrf.matrices import (
     lag_matrix,
     truncate,
     _check_data,
+    _check_length,
     _get_xy,
+    Array,
+    ArrayList,
 )
+import array_api_compat
 
 try:
     from matplotlib import pyplot as plt
@@ -34,7 +40,7 @@ class TRF:
     """
     Temporal response function.
 
-    A (multivariate) regression using time lagged input features which can be used as
+    A (multivariable) regression using time lagged input features which can be used as
     an encoding model to predict brain responses from stimulus features or as a decoding
     model to predict stimulus features from brain responses.
 
@@ -74,18 +80,18 @@ class TRF:
 
     def __init__(
         self,
-        direction=1,
-        kind="multi",
-        zeropad=True,
-        method="ridge",
-        preload=True,
-        metric=pearsonr,
+        direction: Literal[1, -1] = 1,
+        kind: Literal["multi", "single"] = "multi",
+        zeropad: bool = True,
+        method: Literal["ridge", "tikhonov", "banded"] = "ridge",
+        preload: bool = True,
+        metric: callable = pearsonr,
     ):
-        self.weights = None
-        self.bias = None
-        self.times = None
-        self.fs = None
-        self.regularization = None
+        self.weights: Array = None
+        self.bias: Array = None
+        self.times: Array = None
+        self.fs: int = None
+        self.regularization: Union[int, float] = None
         if not callable(metric):
             raise ValueError("Metric function must be callable")
         else:
@@ -111,13 +117,13 @@ class TRF:
         else:
             raise ValueError('Method must be either "ridge", "tikhonov" or "banded"!')
 
-    def __radd__(self, trf):
+    def __radd__(self, trf: TRF) -> TRF:
         if trf == 0:
             return self.copy()
         else:
             return self.__add__(trf)
 
-    def __add__(self, trf):
+    def __add__(self, trf: TRF) -> TRF:
         if not isinstance(trf, TRF):
             raise TypeError("Can only add to another TRF instance!")
         if not (self.direction == trf.direction) and (self.kind == trf.kind):
@@ -127,7 +133,7 @@ class TRF:
         trf_new.bias += trf.bias
         return trf_new
 
-    def __truediv__(self, num):
+    def __truediv__(self, num: Union[int, float]) -> TRF:
         trf_new = self.copy()
         trf_new.weights /= num
         trf_new.bias /= num
@@ -135,17 +141,17 @@ class TRF:
 
     def train(
         self,
-        stimulus,
-        response,
-        fs,
-        tmin,
-        tmax,
-        regularization,
-        bands=None,
-        k=-1,
-        average=True,
-        seed=None,
-        verbose=True,
+        stimulus: Union[Array, ArrayList],
+        response: Union[Array, ArrayList],
+        fs: int,
+        tmin: float,
+        tmax: float,
+        regularization: Union[Union[int, float], List[Union[int, float]]],
+        bands: Union[None, List[int]] = None,
+        k: int = -1,
+        average: Union[bool, List[int]] = True,
+        seed: Union[None, int] = None,
+        verbose: bool = True,
     ):
         """
         Optimize the regularization parameter.
@@ -196,25 +202,31 @@ class TRF:
 
         Returns
         -------
-        metric : list
+        list
             When providing multiple `regularization` values this returns the metric as
             computed by the metric function defined in the `TRF.metric` attribute
             for every regularization value.
         """
         if average is False:
             raise ValueError("Average must be True or a list of indices!")
-        stimulus, response, n_trials = _check_data(stimulus, response)
-        if not np.isscalar(regularization):
+        stimulus, xps = _check_data(stimulus)
+        response, xpr = _check_data(response)
+        n_trials = _check_length(stimulus, response)
+        if not xps == xpr:
+            raise TypeError("stimulus and response trials must be of the same type!")
+        else:
+            xp = xps
+        if not xp.isscalar(regularization):
             k = _check_k(k, n_trials)
         x, y, tmin, tmax = _get_xy(stimulus, response, tmin, tmax, self.direction)
-        lags = list(range(int(np.floor(tmin * fs)), int(np.ceil(tmax * fs)) + 1))
+        lags = list(range(int(xp.floor(tmin * fs)), int(xp.ceil(tmax * fs)) + 1))
         if self.method == "banded":
             coefficients = list(product(regularization, repeat=len(bands)))
             regularization = [
-                banded_regularization(len(lags), c, bands) for c in coefficients
+                banded_regularization(len(lags), c, bands, xp) for c in coefficients
             ]
-        if np.isscalar(regularization):
-            self._train(x, y, fs, tmin, tmax, regularization)
+        if xp.isscalar(regularization):
+            self._train(x, y, fs, tmin, tmax, regularization, xp)
             return
         else:  # run cross-validation once per regularization parameter
             # pre-compute covariance matrices
@@ -225,7 +237,7 @@ class TRF:
                 )
             else:
                 cov_xx, cov_xy = None, None
-            metric = np.zeros(len(regularization))
+            metric = xp.zeros(len(regularization))
             for ir in _progressbar(
                 range(len(regularization)),
                 "Hyperparameter optimization",
@@ -245,43 +257,51 @@ class TRF:
                     average=average,
                     verbose=verbose,
                 )
-            best_regularization = list(regularization)[np.argmax(metric)]
-            self._train(x, y, fs, tmin, tmax, best_regularization)
+            best_regularization = list(regularization)[xp.argmax(metric)]
+            self._train(x, y, fs, tmin, tmax, best_regularization, xp)
             return metric
 
-    def _train(self, x, y, fs, tmin, tmax, regularization):
-        if isinstance(regularization, np.ndarray):  # check if matrix is diagonal
-            if (
-                np.count_nonzero(regularization - np.diag(np.diagonal(regularization)))
-                > 0
-            ):
-                raise ValueError(
-                    "Regularization parameter must be a single number or a diagonal matrix!"
-                )
+    def _train(
+        self,
+        x: ArrayList,
+        y: ArrayList,
+        fs: int,
+        tmin: float,
+        tmax: float,
+        regularization: Union[int, float, Array],
+        xp: ModuleType,
+    ):
+        if isinstance(regularization, xp.ndarray):  # check if matrix is diagonal
+            assert (
+                xp.count_nonzero(regularization - xp.diag(xp.diagonal(regularization)))
+                == 0
+            ), "Regularization matrix is not diagonal!"
         self.fs, self.regularization = fs, regularization
-        lags = list(range(int(np.floor(tmin * fs)), int(np.ceil(tmax * fs)) + 1))
+        lags = list(range(int(xp.floor(tmin * fs)), int(xp.ceil(tmax * fs)) + 1))
         cov_xx, cov_xy = covariance_matrices(x, y, lags, self.zeropad, preload=False)
-        regmat = regularization_matrix(cov_xx.shape[1], self.method)
+        regmat = regularization_matrix(cov_xx.shape[1], xp, self.method)
         regmat *= regularization / (1 / self.fs)
-        weight_matrix = np.matmul(np.linalg.inv(cov_xx + regmat), cov_xy) / (
+        weight_matrix = xp.matmul(xp.linalg.inv(cov_xx + regmat), cov_xy) / (
             1 / self.fs
         )
         self.bias = weight_matrix[0:1]
         if self.bias.ndim == 1:  # add empty dimension for single feature models
-            self.bias = np.expand_dims(self.bias, axis=0)
+            self.bias = xp.expand_dims(self.bias, axis=0)
         self.weights = weight_matrix[1:].reshape(
             (x[0].shape[1], len(lags), y[0].shape[1]), order="F"
         )
-        self.times = np.array(lags) / fs
+        self.times = xp.array(lags) / fs
         self.fs = fs
 
     def predict(
         self,
-        stimulus=None,
-        response=None,
-        lag=None,
-        average=True,
-    ):
+        stimulus: Union[None, Array, ArrayList] = None,
+        response: Union[None, Array, ArrayList] = None,
+        lag: Union[None, int, list] = None,
+        average: Union[bool, List[int]] = True,
+    ) -> Union[
+        Union[Array, ArrayList], Tuple[Union[Array, ArrayList]], Union[float, Array]
+    ]:
         """
         Predict response from stimulus (or vice versa) using the trained model.
 
@@ -291,28 +311,28 @@ class TRF:
 
         Parameters
         ----------
-        stimulus: None or list or numpy.ndarray
+        stimulus: None or array-like or list of array-like
             Either a 2-D samples-by-features array, if the data contains only one trial
             or a list of such arrays of it contains multiple trials. The second
             dimension can be omitted if there only is a single stimulus feature
             (e.g. envelope). When using a forward model, this must be specified.
-        response: None or list or numpy.ndarray
+        response: None or array-like or list of array-like
             Either a 2-D samples-by-channels array, if the data contains only one
             trial or a list of such arrays of it contains multiple trials. Must be
             provided when using a backward model.
-        lag: None or in or list
+        lag: None or int or list of int
             If not None (default), only use the specified lags for prediction.
             The provided values index the elements in self.times.
-        average: bool or list or numpy.ndarray
+        average: bool or int or list of int
             If True (default), average metric across all predicted features (e.g. channels
             in the case of forward modelling). If `average` is an array of indices only
             average those features. If `False`, return each predicted feature's metric.
 
         Returns
         -------
-        prediction: numpy.ndarray
-            Predicted stimulus or response
-        metric: float or numpy.ndarray
+        array-like or list of array-like
+            Predicted stimulus or response.
+        float or array-like
             If both stimulus and response are provided, metric is computed by the
             metric function defined in the attribute `TRF.metric`.
             If average is False, an array containing the metric for each feature
@@ -325,30 +345,41 @@ class TRF:
             raise ValueError("Need stimulus to predict with a forward model!")
         elif self.direction == -1 and response is None:
             raise ValueError("Need response to predict with a backward model!")
+        stimulus, xps = _check_data(stimulus)
+        response, xpr = _check_data(response)
+        n_trials = _check_length(stimulus, response)
+        if not xps == xpr:
+            raise TypeError("stimulus and response trials must be of the same type!")
         else:
-            stimulus, response, n_trials = _check_data(stimulus, response)
+            xp = xps
         if stimulus is None:
             stimulus = [None for _ in range(n_trials)]
         if response is None:
             response = [None for _ in range(n_trials)]
 
-        x, y = _get_xy(stimulus, response, direction=self.direction)
-        prediction = [np.zeros((x_i.shape[0], self.weights.shape[-1])) for x_i in x]
+        x, y, _, _ = _get_xy(
+            stimulus,
+            response,
+            tmin=self.times[0],
+            tmax=self.times[-1],
+            direction=self.direction,
+        )
+        prediction = [xp.zeros((x_i.shape[0], self.weights.shape[-1])) for x_i in x]
         metric = []
         for i, (x_i, y_i) in enumerate(zip(x, y)):
             lags = list(
                 range(
-                    int(np.floor(self.times[0] * self.fs)),
-                    int(np.ceil(self.times[-1] * self.fs)) + 1,
+                    int(xp.floor(self.times[0] * self.fs)),
+                    int(xp.ceil(self.times[-1] * self.fs)) + 1,
                 )
             )
             w = self.weights.copy()
             if lag is not None:  # select lag and corresponding weights
                 if not isinstance(lag, Iterable):
                     lag = [lag]
-                lags = list(np.array(lags)[lag])
+                lags = list(xp.array(lags)[lag])
                 w = w[:, lag, :]
-            w = np.concatenate(
+            w = xp.concatenate(
                 [
                     self.bias,
                     w.reshape(
@@ -364,11 +395,11 @@ class TRF:
                 metric.append(self.metric(y_i, y_pred))
             prediction[i][:] = y_pred
         if y[0] is not None:
-            metric = np.mean(metric, axis=0)  # average across trials
-            if isinstance(average, list) or isinstance(average, np.ndarray):
+            metric = xp.mean(metric, axis=0)  # average across trials
+            if hasattr(average, "__len__"):
                 metric = metric[average]  # select a subset of predictions
             if average is not False:
-                metric = np.mean(metric)
+                metric = xp.mean(metric)
             return prediction, metric
         else:
             return prediction
@@ -389,28 +420,28 @@ class TRF:
 
         Returns
         -------
-        trf: model.TRF
+        TRF
             New TRF instance with the transformed forward weights
         """
-        assert self.direction == -1
+        assert self.direction == -1, "This method only works for backward models!"
 
-        _, response, n_trials = _check_data(None, response)
-        stim_pred = self.predict(response=response)
-
-        Cxx = 0
-        Css = 0
+        response, xp = _check_data(response)
+        stimulus = self.predict(response=response)
+        n_trials = len(response)
+        cov_xx = 0
+        cov_yy = 0
         trf = self.copy()
-        trf.times = np.asarray([-i for i in reversed(trf.times)])
+        trf.times = xp.asarray([-i for i in reversed(trf.times)])
         trf.direction = 1
         for i in range(n_trials):
-            Cxx = Cxx + response[i].T @ response[i]
-            Css = Css + stim_pred[i].T @ stim_pred[i]
-        nStimChan = trf.weights.shape[-1]
-        for i in range(nStimChan):
-            trf.weights[..., i] = Cxx @ self.weights[..., i] / Css[i, i]
+            cov_xx = cov_xx + response[i].T @ response[i]
+            cov_yy = cov_yy + stimulus[i].T @ stimulus[i]
+        n_channels = trf.weights.shape[-1]
+        for i in range(n_channels):
+            trf.weights[..., i] = cov_xx @ self.weights[..., i] / cov_yy[i, i]
 
-        trf.weights = np.flip(trf.weights.T, axis=1)
-        trf.bias = np.zeros(trf.weights.shape[-1])
+        trf.weights = xp.flip(trf.weights.T, axis=1)
+        trf.bias = xp.zeros(trf.weights.shape[-1])
         return trf
 
     def save(self, path):
@@ -475,6 +506,7 @@ class TRF:
         Returns:
             fig (matplotlib.figure.Figure): If now axes was provided and a new figure is created, it is returned.
         """
+        xp = array_api_compat.array_namespace(self.weights)
         if plt is None:
             raise ModuleNotFoundError("Need matplotlib to plot TRF!")
         if self.direction == -1:
@@ -494,6 +526,7 @@ class TRF:
             channel = 0
         if channel is None and feature is None:
             raise ValueError("You must specify a subset of channels or features!")
+        image_ylabel = ""
         if feature is not None:
             image_ylabel = "channel"
             if isinstance(feature, int):
@@ -533,7 +566,7 @@ class TRF:
                 aspect="auto",
                 extent=[0, weights.shape[0], 0, weights.shape[1]],
             )
-            extent = np.asarray(im.get_extent(), dtype=float)
+            extent = xp.asarray(im.get_extent(), dtype=float)
             extent[:2] *= scale
             im.set_extent(extent)
             ax.set(
@@ -571,6 +604,7 @@ class TRF:
         evokeds: list
             One Evoked instance for each included TRF feature.
         """
+        xp = array_api_compat.array_namespace(self.weights)
         if mne is False:
             raise ModuleNotFoundError("To use this function, mne must be installed!")
         if self.direction == -1:
@@ -593,7 +627,7 @@ class TRF:
         else:
             raise ValueError
         if isinstance(include, list) or isinstance(include, np.ndarray):
-            weights = weights[np.asarray(include), :, :]
+            weights = weights[xp.asarray(include), :, :]
         evokeds = []
         for w in weights:
             evoked = mne.EvokedArray(w.T.copy(), mne_info, tmin=self.times[0], **kwargs)
@@ -650,11 +684,7 @@ def load_sample_data(path=None, n_segments=1, normalize=True):
     stimulus = np.array_split(stimulus, n_segments)
     response = np.array_split(response, n_segments)
     if normalize:
-        for i in range(len(stimulus)):
-            stimulus[i] = (stimulus[i] - stimulus[i].mean(axis=0)) / stimulus[i].std(
-                axis=0
-            )
-            response[i] = (response[i] - response[i].mean(axis=0)) / response[i].std(
-                axis=0
-            )
+        for i, (s, r) in enumerate(zip(stimulus, response)):
+            stimulus[i] = (s - s.mean(axis=0)) / s.std(axis=0)
+            response[i] = (r - r.mean(axis=0)) / r.std(axis=0)
     return stimulus, response, fs

--- a/mtrf/model.py
+++ b/mtrf/model.py
@@ -638,7 +638,9 @@ class TRF:
         return evokeds
 
 
-def load_sample_data(path=None, n_segments=1, normalize=True):
+def load_sample_data(
+    path: Union[None, str, Path] = None, n_segments: int = 1, normalize: bool = True
+) -> Tuple[ArrayList, ArrayList, int]:
     """
     Load sample of brain responses to naturalistic speech.
 
@@ -654,6 +656,12 @@ def load_sample_data(path=None, n_segments=1, normalize=True):
         Destination where the sample data is stored or will be downloaded to. If None
         (default), a folder called mtrf_data in the users home directory is assumed
         and created if it does not exist.
+
+    n_segments: int
+        Number of segments (i.e. trials) the data are divided into.
+
+    normalize: bool
+        If True (default) subtract the mean and divide by the standard deviation.
 
     Returns
     -------

--- a/mtrf/stats.py
+++ b/mtrf/stats.py
@@ -321,7 +321,7 @@ def _crossval(
         random.seed(seed)
 
     reg_mat_size = x[0].shape[-1] * len(lags) + 1
-    regmat = regularization_matrix(reg_mat_size, model.method)
+    regmat = regularization_matrix(reg_mat_size, xp, model.method)
     regmat *= regularization / (1 / fs)
 
     n_trials = len(x)

--- a/mtrf/stats.py
+++ b/mtrf/stats.py
@@ -118,7 +118,7 @@ def crossval(
     """
     stimulus, xps = _check_data(stimulus)
     response, xpr = _check_data(response)
-    n_trials = _check_length(stimulus, response)
+    stimulus, response, n_trials = _check_length(stimulus, response)
     assert n_trials >= k, f"Not enough trials for {k}-fold cross-validation"
     if not xps == xpr:
         raise TypeError("stimulus and response trials must be of the same type!")
@@ -227,10 +227,11 @@ def nested_crossval(
     """
     stimulus, xps = _check_data(stimulus)
     response, xpr = _check_data(response)
-    n_trials = _check_length(stimulus, response)
+    stimulus, response, n_trials = _check_length(stimulus, response)
     assert (
         n_trials >= k + 1 and n_trials >= 3
     ), f"Not enough trials for {k}-fold nested cross-validation!"
+    k = _check_k(k, n_trials)
     if not xps == xpr:
         raise TypeError("stimulus and response trials must be of the same type!")
     else:
@@ -294,6 +295,7 @@ def nested_crossval(
             tmin,
             tmax,
             regularization_split_i,
+            xp,
         )
         _, metric_test[split_i] = model.predict(
             [stimulus[i] for i in idx_test], [response[i] for i in idx_test]
@@ -427,7 +429,7 @@ def permutation_distribution(
     """
     stimulus, xps = _check_data(stimulus)
     response, xpr = _check_data(response)
-    n_trials = _check_length(stimulus, response)
+    stimulus, response, n_trials = _check_length(stimulus, response)
     assert n_trials >= k, f"Not enough trials for {k}-fold cross-validation"
     if not xps == xpr:
         raise TypeError("stimulus and response trials must be of the same type!")

--- a/mtrf/stats.py
+++ b/mtrf/stats.py
@@ -2,38 +2,43 @@ import random
 import sys
 from collections.abc import Iterable
 from itertools import product
-import numpy as np
+from typing import List, Union
+import array_api_compat
 from mtrf.matrices import (
     regularization_matrix,
     covariance_matrices,
     banded_regularization,
     _check_data,
+    _check_length,
     _get_xy,
+    Array,
+    ArrayList,
 )
 
 
-def neg_mse(y, y_pred):
+def neg_mse(y: Array, y_pred: Array) -> Array:
     """
     Compute negative mean suqare error (mse) between predicted
     and observed data
 
     Parameters
     ----------
-    y: np.ndarray
+    y: Array
         samples-by-features matrix of observed data.
-    y_pred: np.ndarray
+    y_pred: Array
         samples-by-features matrix of predicted data.
 
     Returns
     -------
-    neg_mse: np.ndarray
+    neg_mse: Array
         Negative mse (-mse) for each feature in y.
     """
-    mse = np.mean((y - y_pred) ** 2, axis=0)
+    xp = array_api_compat.array_namespace(y)
+    mse = xp.mean((y - y_pred) ** 2, axis=0)
     return -mse
 
 
-def pearsonr(y, y_pred):
+def pearsonr(y: Array, y_pred: Array) -> Array:
     """
     Compute Pearson's correlation coefficient between predicted
     and observed data
@@ -50,7 +55,8 @@ def pearsonr(y, y_pred):
     r: np.ndarray
         Pearsons r for each feature in y.
     """
-    r = np.mean((y - y.mean(0)) * (y_pred - y_pred.mean(0)), 0) / (
+    xp = array_api_compat.array_namespace(y)
+    r = xp.mean((y - y.mean(0)) * (y_pred - y_pred.mean(0)), 0) / (
         y.std(0) * y_pred.std(0)
     )
     return r
@@ -58,17 +64,17 @@ def pearsonr(y, y_pred):
 
 def crossval(
     model,
-    stimulus,
-    response,
-    fs,
-    tmin,
-    tmax,
-    regularization,
-    k=-1,
-    seed=None,
-    average=True,
-    verbose=True,
-):
+    stimulus: ArrayList,
+    response: ArrayList,
+    fs: int,
+    tmin: float,
+    tmax: float,
+    regularization: Union[int, float],
+    k: int = -1,
+    seed: Union[int, None] = None,
+    average: Union[bool, List[int]] = True,
+    verbose: bool = True,
+) -> Union[float, Array]:
     """
     Test model metric using k-fold cross-validation.
 
@@ -78,13 +84,13 @@ def crossval(
 
     Parameters
     ----------
-    model: model.TRF
+    model: TRF
         Base model used for cross-validation.
-    stimulus: list
+    stimulus: list of array-like
         Each element must contain one trial's stimulus in a two-dimensional
         samples-by-features array (second dimension can be omitted if there is
         only a single feature.
-    response: list
+    respnse: list of array-like
         Each element must contain one trial's response in a two-dimensional
         samples-by-channels array.
     fs: int
@@ -107,9 +113,17 @@ def crossval(
 
     Returns
     -------
-    metric: float or numpy.ndarray
+    metric: float or array-like
         Metric as computed by the metric function in the attribute `model.metric`.
     """
+    stimulus, xps = _check_data(stimulus)
+    response, xpr = _check_data(response)
+    n_trials = _check_length(stimulus, response)
+    assert n_trials >= k, f"Not enough trials for {k}-fold cross-validation"
+    if not xps == xpr:
+        raise TypeError("stimulus and response trials must be of the same type!")
+    else:
+        xp = xps
     if isinstance(regularization, Iterable):
         raise ValueError(
             "Crossval only accepts a single scalar for regularization! "
@@ -120,9 +134,8 @@ def crossval(
     trf = model.copy()
     if seed is not None:
         random.seed(seed)
-    stimulus, response, _ = _check_data(stimulus, response, min_len=2)
     x, y, tmin, tmax = _get_xy(stimulus, response, tmin, tmax, model.direction)
-    lags = list(range(int(np.floor(tmin * fs)), int(np.ceil(tmax * fs)) + 1))
+    lags = list(range(int(xp.floor(tmin * fs)), int(xp.ceil(tmax * fs)) + 1))
     cov_xx, cov_xy = covariance_matrices(x, y, lags, model.zeropad, trf.preload)
     metric = _crossval(
         model,
@@ -134,6 +147,7 @@ def crossval(
         fs,
         regularization,
         k,
+        xp,
         average,
         verbose,
     )
@@ -211,18 +225,24 @@ def nested_crossval(
     best_regularization: numpy.ndarray
         Optimal regularization values for all k training sets.
     """
-    if average is False and not np.isscalar(regularization):
+    stimulus, xps = _check_data(stimulus)
+    response, xpr = _check_data(response)
+    n_trials = _check_length(stimulus, response)
+    assert (
+        n_trials >= k + 1 and n_trials >= 3
+    ), f"Not enough trials for {k}-fold nested cross-validation!"
+    if not xps == xpr:
+        raise TypeError("stimulus and response trials must be of the same type!")
+    else:
+        xp = xps
+    if average is False and not xp.isscalar(regularization):
         raise ValueError("Average must be True or a list of indices!")
-    stimulus, response, n_trials = _check_data(stimulus, response)
-    if len(stimulus) < 3:
-        raise ValueError("Nested cross-validation requires at least three trials!")
-    k = _check_k(k, n_trials)
     x, y, tmin, tmax = _get_xy(stimulus, response, tmin, tmax, model.direction)
-    lags = list(range(int(np.floor(tmin * fs)), int(np.ceil(tmax * fs)) + 1))
+    lags = list(range(int(xp.floor(tmin * fs)), int(xp.ceil(tmax * fs)) + 1))
     if model.method == "banded":
         coefficients = list(product(regularization, repeat=2))
         regularization = [
-            banded_regularization(len(lags), c, bands) for c in coefficients
+            banded_regularization(len(lags), c, bands, xp) for c in coefficients
         ]
 
     if model.preload:
@@ -230,15 +250,15 @@ def nested_crossval(
     else:
         cov_xx, cov_xy = None, None
 
-    splits = np.array_split(np.arange(n_trials), k)
+    splits = xp.array_split(xp.arange(n_trials), k)
     n_splits = len(splits)
-    metric_test = np.zeros(n_splits)
+    metric_test = xp.zeros(n_splits)
     best_regularization = []
     for split_i in range(n_splits):
         idx_test = splits[split_i]
-        idx_train_val = np.concatenate(splits[:split_i] + splits[split_i + 1 :])
-        if not np.isscalar(regularization):
-            metric = np.zeros(len(regularization))
+        idx_train_val = xp.concatenate(splits[:split_i] + splits[split_i + 1 :])
+        if not xp.isscalar(regularization):
+            metric = xp.zeros(len(regularization))
             for ir in _progressbar(
                 range(len(regularization)),
                 "Hyperparameter optimization",
@@ -259,11 +279,12 @@ def nested_crossval(
                     fs,
                     regularization[ir],
                     k - 1,
+                    xp,
                     seed=seed,
                     average=average,
                     verbose=verbose,
                 )
-            regularization_split_i = list(regularization)[np.argmax(metric)]
+            regularization_split_i = list(regularization)[xp.argmax(metric)]
         else:
             regularization_split_i = regularization
         model._train(
@@ -291,6 +312,7 @@ def _crossval(
     fs,
     regularization,
     k,
+    xp,
     average=True,
     verbose=True,
     seed=None,
@@ -304,18 +326,18 @@ def _crossval(
 
     n_trials = len(x)
     k = _check_k(k, n_trials)
-    splits = np.arange(n_trials)
+    splits = xp.arange(n_trials)
     random.shuffle(splits)
-    splits = np.array_split(splits, k)
+    splits = xp.array_split(splits, k)
 
     if average is True:
-        metric = np.zeros(k)
+        metric = xp.zeros(k)
     else:
-        metric = np.zeros((k, y[0].shape[-1]))
+        metric = xp.zeros((k, y[0].shape[-1]))
 
     for isplit in _progressbar(range(len(splits)), "Cross-validating", verbose=verbose):
         idx_val = splits[isplit]
-        idx_train = np.concatenate(splits[:isplit] + splits[isplit + 1 :])  # flatten
+        idx_train = xp.concatenate(splits[:isplit] + splits[isplit + 1 :])  # flatten
         if cov_xx is None:
             x_train = [x[i] for i in idx_train]
             y_train = [y[i] for i in idx_train]
@@ -325,11 +347,11 @@ def _crossval(
         else:
             cov_xx_hat = cov_xx[idx_train].mean(axis=0)
             cov_xy_hat = cov_xy[idx_train].mean(axis=0)
-        w = np.matmul(np.linalg.inv(cov_xx_hat + regmat), cov_xy_hat) / (1 / fs)
+        w = xp.matmul(xp.linalg.inv(cov_xx_hat + regmat), cov_xy_hat) / (1 / fs)
         trf = model.copy()
-        trf.times, trf.bias, trf.fs = np.array(lags) / fs, w[0:1], fs
+        trf.times, trf.bias, trf.fs = xp.array(lags) / fs, w[0:1], fs
         if trf.bias.ndim == 1:
-            trf.bias = np.expand_dims(trf.bias, 1)
+            trf.bias = xp.expand_dims(trf.bias, 1)
         trf.weights = w[1:].reshape(
             (x[0].shape[-1], len(lags), y[0].shape[-1]), order="F"
         )
@@ -338,7 +360,7 @@ def _crossval(
         # to pass the right variable as stimulus and response to TRF.predict
         if model.direction == 1:
             _, metric_test = trf.predict(x_test, y_test, None, average)
-        elif model.direction == -1:
+        else:
             _, metric_test = trf.predict(y_test, x_test, None, average)
         metric[isplit] = metric_test
     return metric.mean(axis=0)
@@ -403,40 +425,47 @@ def permutation_distribution(
         Metric as computed by the metric function in  the attribute `model.metric`
         for each permutation.
     """
+    stimulus, xps = _check_data(stimulus)
+    response, xpr = _check_data(response)
+    n_trials = _check_length(stimulus, response)
+    assert n_trials >= k, f"Not enough trials for {k}-fold cross-validation"
+    if not xps == xpr:
+        raise TypeError("stimulus and response trials must be of the same type!")
+    else:
+        xp = xps
     if seed:
-        np.random.seed(seed)
-    stimulus, response, n_trials = _check_data(stimulus, response, min_len=2, crop=True)
+        xp.random.seed(seed)
     x, y, tmin, tmax = _get_xy(stimulus, response, tmin, tmax, model.direction)
     min_len = min([len(x_i) for x_i in x])
-    for i in range(len(x)):
-        x[i], y[i] = x[i][:min_len], y[i][:min_len]
+    for i, x_i in enumerate(x):
+        x[i], y[i] = x_i[:min_len], y[i][:min_len]
     k = _check_k(k, n_trials)
-    idx = np.arange(n_trials)
-    combinations = np.transpose(np.meshgrid(idx, idx)).reshape(-1, 2)
+    idx = xp.arange(n_trials)
+    combinations = xp.transpose(xp.meshgrid(idx, idx)).reshape(-1, 2)
     models = []
     for c in _progressbar(combinations, "Preparing models", verbose=verbose):
         trf = model.copy()
         trf.train(stimulus[c[0]], response[c[1]], fs, tmin, tmax, regularization)
         models.append(trf)
-    metric = np.zeros(n_permute)
+    metric = xp.zeros(n_permute)
     for iperm in _progressbar(range(n_permute), "Permuting", verbose=verbose):
         idx = []
         for i in range(len(x)):  # make sure each x only appears once
-            idx.append(random.choice(np.where(combinations[:, 0] == i)[0]))
+            idx.append(random.choice(xp.where(combinations[:, 0] == i)[0]))
         random.shuffle(idx)
-        idx = np.array_split(idx, k)
+        idx = xp.array_split(idx, k)
         perm_metric = []
-        for isplit in range(len(idx)):
+        for isplit in range(k):
             idx_val = idx[isplit]
-            idx_train = np.concatenate(idx[:isplit] + idx[isplit + 1 :])
-            perm_model = np.mean([models[i] for i in idx_train])
+            idx_train = xp.concatenate(idx[:isplit] + idx[isplit + 1 :])
+            perm_model = xp.mean([models[i] for i in idx_train])
             stimulus_val = [stimulus[combinations[i][0]] for i in idx_val]
             response_val = [response[combinations[i][1]] for i in idx_val]
             _, fold_metric = perm_model.predict(
                 stimulus_val, response_val, None, average
             )
             perm_metric.append(fold_metric)
-        metric[iperm] = np.mean(perm_metric)
+        metric[iperm] = xp.mean(perm_metric)
 
     return metric
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author="powerfulbean",
     license="MIT",
     python_requires=">=3.8",
-    install_requires=["numpy, array-api-compat"],
+    install_requires=["numpy", "array-api-compat"],
     extras_require={
         "testing": [
             "requests",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     url="http://github.com/powerfulbean/mTRFpy",
     author="powerfulbean",
     license="MIT",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=["numpy", "array-api-compat"],
     extras_require={
         "testing": [

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author="powerfulbean",
     license="MIT",
     python_requires=">=3.8",
-    install_requires=["numpy"],
+    install_requires=["numpy, array-api-compat"],
     extras_require={
         "testing": [
             "requests",

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setup(
             "requests",
             "flake8",
             "black",
+            "dask",
+            "array-api-strict",
             "pytest",
             "tqdm",
             "matplotlib",

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,35 +1,50 @@
 from pathlib import Path
 import numpy as np
-from mtrf.model import lag_matrix, TRF, load_sample_data
+import dask.array as da
+import array_api_strict
 from mtrf.matrices import _check_data
+from mtrf.model import lag_matrix, TRF, load_sample_data
+
 
 root = Path(__file__).parent.absolute()
 
 
-def test_check_data():
-    n = np.random.randint(2, 10)
-    stimulus, response, _ = load_sample_data(n_segments=n)
-    stimulus, response, n_trials = _check_data(
-        stimulus=stimulus, response=response, min_len=n, crop=False
-    )
-    assert n_trials == n
-    stimulus, response, _ = _check_data(
-        stimulus=stimulus, response=response, min_len=n, crop=True
-    )
-    stimulus, _, _ = _check_data(
-        stimulus=stimulus, response=None, min_len=n, crop=False
-    )
-    assert all([s.shape == stimulus[0].shape for s in stimulus])
-    assert all([r.shape == response[0].shape for r in response])
-    _, response, _ = _check_data(
-        stimulus=None, response=response, min_len=n, crop=False
-    )
-    np.testing.assert_raises(ValueError, _check_data, stimulus, response, n + 1)
-    np.testing.assert_raises(ValueError, _check_data, stimulus, response[:-1], n)
+def test_sample_data_segmentation():
+    for _ in range(5):
+        n = np.random.randint(1, 10)
+        stimulus, response, _ = load_sample_data(n_segments=n)
+        assert all([isinstance(data, list) for data in [stimulus, response]])
+        assert len(stimulus) == len(response)
+        assert all([len(s) == len(r) for s, r in zip(stimulus, response)])
 
 
-def test_lag_matrix():
-    stimulus, response, fs = load_sample_data(n_segments=1)
+def test_sample_data_normalization():
+    stimulus, response, _ = load_sample_data(normalize=True)
+    np.testing.assert_almost_equal(stimulus[0].mean(), 0, decimal=12)
+    np.testing.assert_almost_equal(response[0].mean(), 0, decimal=12)
+    np.testing.assert_almost_equal(stimulus[0].std(), 1, decimal=12)
+    np.testing.assert_almost_equal(response[0].std(), 1, decimal=12)
+    stimulus, response, _ = load_sample_data(normalize=False)
+    np.testing.assert_almost_equal(stimulus[0].mean(), 0.11, decimal=1)
+    np.testing.assert_almost_equal(response[0].mean(), -0.01, decimal=1)
+    np.testing.assert_almost_equal(stimulus[0].std(), 0.15, decimal=1)
+    np.testing.assert_almost_equal(response[0].std(), 8.69, decimal=1)
+
+
+def test_array_namespace_is_returned():
+    stimulus, _, _ = load_sample_data(n_segments=5)
+    stimulus, xp = _check_data(stimulus)
+    assert xp.__name__.split(".")[-1] == "numpy", "Numpy array wasn't detected!"
+    stimulus = [da.from_array(s) for s in stimulus]
+    stimulus, xp = _check_data(stimulus)
+    assert xp.__name__.split(".")[1] == "dask", "Dask array wasn't detected!"
+    stimulus = [array_api_strict.asarray(s) for s in stimulus]
+    stimulus, xp = _check_data(stimulus)
+    assert xp.__name__ == "array_api_strict", "Array-API array wasn't detected!"
+
+
+def test_lag_matrix_size():
+    stimulus, _, fs = load_sample_data(n_segments=1)
     stimulus = stimulus[0]
     for _ in range(10):
         tmin = np.random.randint(-200, -100) / 1e3
@@ -49,7 +64,7 @@ def test_lag_matrix():
         assert lag_mat.shape[1] == len(lags) * stimulus.shape[1] + 1
 
 
-def test_arithmatic():
+def test_trf_arithmetic():
     trf1 = TRF()
     trf2 = TRF()
     trf1.weights = np.ones((10, 10))


### PR DESCRIPTION
I have added support for array-api as described in gh-38
Now, we can use any kind of array supported by the standard.
For example, one could use CUpy and compute TRFs with GPU acceleration.
Thanks to the magic of `array-api-compat` this does not require any breaking API changes.

I did make some changes to private functions though and adapted the tests accordingly.
I also changed a few outdated docstrings and started adding type hints.